### PR TITLE
[BUG] - Dot, Space and Line component bug on margin and size properties #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-receipt-slip",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The react-receipt-slip easiest way to create a receipt template.",
   "keywords": [
     "React",

--- a/src/Paper.tsx
+++ b/src/Paper.tsx
@@ -17,7 +17,7 @@ export const Line = styled.div<LineProps>`
     width: 100%;
     height: 0px;
     margin: ${(props) => {
-        if (props.margin) {
+        if (props.margin && props.margin.length === 2) {
             return `${props.margin[1]}px ${props.margin[0]}px`
         }
         return '0px 0px 2px 0px'
@@ -29,7 +29,7 @@ export const Dot = styled.hr<DotProps>`
     margin-bottom: ${(props) => props.vmar ? props.vmar[1] : 0}px;
     
     margin: ${(props) => {
-        if (props.margin) {
+        if (props.margin && props.margin.length === 2) {
             return `${props.margin[1]}px ${props.margin[0]}px`
         }
         return '5px 5px'
@@ -113,7 +113,7 @@ export const TableCell = styled.td<TableCellProps & TextProps>`
 `
 export const Space = styled.div<SpaceProps>`
     margin: ${(props) => {
-        if (props.size) {
+        if (props.size && props.size.length === 2) {
             return `${props.size[1]}px ${props.size[0]}px;`
         } else {
             return `5px 5px;`


### PR DESCRIPTION
### Stable Release v1.1.2 - 07/15/2025

**🚀 Bug Fixed**
1. `<Dot>` margin property
2. `<Line>` margin property
3. `<Space>` size property

Supported Documentations
1. [GitHub Repository](https://github.com/devychan/react-receipt-slip)
4. [NPM Package](https://www.npmjs.com/package/react-receipt-slip/v/1.1.2)
5. [Sample Usage](https://codesandbox.io/p/sandbox/7wtlkl)

**Full Changelog**: https://github.com/devychan/react-receipt-slip/commits/v1.1.2